### PR TITLE
Update tidyr to dplyr 1.0.0 (#914)

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -65,15 +65,22 @@ str_extract <- function(x, into, regex, convert = FALSE) {
   }
 
   out <- as_tibble(matches, .name_repair = "minimal")
+  out <- as.list(out)
 
   # Handle duplicated names
   if (anyDuplicated(into)) {
-    pieces <- split(as.list(out), into)
-    out <- as_tibble(map(pieces, pmap_chr, paste0, sep = ""))
-  } else {
-    names(out) <- as_utf8_character(into)
+    pieces <- split(out, into)
+    into <- names(pieces)
+    out <- map(pieces, pmap_chr, paste0, sep = "")
   }
-  out <- out[!is.na(names(out))]
+
+  into <- as_utf8_character(into)
+
+  non_na_into <- !is.na(into)
+  out <- out[non_na_into]
+  names(out) <- into[non_na_into]
+
+  out <- as_tibble(out)
 
   if (convert) {
     out[] <- map(out, type.convert, as.is = TRUE)

--- a/R/nest-legacy.R
+++ b/R/nest-legacy.R
@@ -100,7 +100,8 @@ nest_legacy.tbl_df <- function(data, ..., .key = "data") {
   if (packageVersion("dplyr") < "0.8.0") {
     idx <- dplyr::group_indices(data, !!! syms(group_vars))
   } else {
-    idx <- dplyr::group_indices(data, !!! syms(group_vars), .drop = TRUE)
+    grouped_data <- dplyr::group_by(data, !!! syms(group_vars), .drop = TRUE)
+    idx <- dplyr::group_indices(grouped_data)
   }
 
   representatives <- which(!duplicated(idx))
@@ -225,12 +226,20 @@ list_col_type <- function(x) {
   }
 }
 enframe <- function(x, col_name, .id = NULL) {
-  out <- tibble(dplyr::combine(x))
-  names(out) <- col_name
+  if (!is_list(x)) {
+    x <- list(x)
+  }
+
+  col <- unname(x)
+  col <- vec_unchop(col)
+
+  out <- set_names(list(col), col_name)
+  out <- as_tibble(out)
 
   if (!is_null(.id)) {
     out[[.id]] <- id_col(x)
   }
+
   out
 }
 id_col <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@ reconstruct_tibble <- function(input, output, ungrouped_vars = character()) {
   if (inherits(input, "grouped_df")) {
     old_groups <- dplyr::group_vars(input)
     new_groups <- intersect(setdiff(old_groups, ungrouped_vars), names(output))
-    dplyr::grouped_df(output, new_groups)
+    dplyr::grouped_df(output, new_groups, drop = dplyr::group_by_drop_default(input))
   } else if (inherits(input, "tbl_df")) {
     # Assume name repair carried out elsewhere
     as_tibble(output, .name_repair = "minimal")

--- a/tests/testthat/test-complete.R
+++ b/tests/testthat/test-complete.R
@@ -15,7 +15,7 @@ test_that("preserves grouping", {
   df <- tibble(x = 1:2, y = 1:2, z = 3:4) %>% dplyr::group_by(x)
   out <- complete(df, x, y)
   expect_s3_class(out, "grouped_df")
-  expect_equal(dplyr::groups(out), dplyr::groups(df))
+  expect_equal(dplyr::group_vars(out), dplyr::group_vars(df))
 })
 
 test_that("expands empty factors", {
@@ -39,5 +39,6 @@ test_that("empty expansion returns original", {
 test_that("not drop unspecified levels in complete", {
   df <- tibble(x = 1:3, y = 1:3, z = c("a", "b", "c"))
   df2 <- df %>% complete(z = c("a", "b"))
-  expect_equal(df, df2)
+  expect <- df[c("z", "x", "y")]
+  expect_equal(df2, expect)
 })

--- a/tests/testthat/test-drop-na.R
+++ b/tests/testthat/test-drop-na.R
@@ -26,7 +26,7 @@ test_that("groups are preserved", {
 
   res <- tidyr::drop_na(gdf, y)
   expect_equal(res, gexp)
-  expect_equal(dplyr::groups(res), dplyr::groups(gexp))
+  expect_equal(dplyr::group_vars(res), dplyr::group_vars(gexp))
 })
 
 test_that("empty call drops every row", {

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -13,7 +13,7 @@ test_that("multiple variables in one arg doesn't expand", {
 })
 
 test_that("nesting doesn't expand values", {
-  df <- data.frame(x = 1:2, y = 1:2)
+  df <- tibble(x = 1:2, y = 1:2)
   expect_equal(expand(df, nesting(x, y)), df)
 })
 
@@ -27,7 +27,7 @@ test_that("unnamed data frames are flattened", {
 })
 
 test_that("named data frames are not flattened", {
-  df <- data.frame(x = 1:2, y = 1:2)
+  df <- tibble(x = 1:2, y = 1:2)
   out <- expand(df, x = nesting(x, y))
   expect_equal(out$x, df)
 

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -44,7 +44,7 @@ test_that("groups are preserved", {
   df <- tibble(g = 1, x = "X1") %>% dplyr::group_by(g)
   rs <- df %>% extract(x, c("x", "y"), "(.)(.)")
   expect_equal(class(df), class(rs))
-  expect_equal(dplyr::groups(df), dplyr::groups(rs))
+  expect_equal(dplyr::group_vars(df), dplyr::group_vars(rs))
 })
 
 test_that("informative error message if wrong number of groups", {

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -71,7 +71,7 @@ test_that("group_vars are kept where possible", {
 
   # Can keep
   out <- df %>% dplyr::group_by(x) %>% gather(key, val, y:z)
-  expect_equal(dplyr::groups(out), list(quote(x)))
+  expect_equal(dplyr::group_vars(out), "x")
 })
 
 test_that("overwrites existing vars", {

--- a/tests/testthat/test-nest-legacy.R
+++ b/tests/testthat/test-nest-legacy.R
@@ -5,7 +5,7 @@ test_that("nest turns grouped values into one list-df", {
   out <- nest_legacy(df, y)
   expect_equal(out$x, 1)
   expect_equal(length(out$data), 1L)
-  expect_equal(out$data[[1L]], data.frame(y = 1:3))
+  expect_equal(out$data[[1L]], tibble(y = 1:3))
 })
 
 test_that("nest works with data frames too", {
@@ -13,7 +13,7 @@ test_that("nest works with data frames too", {
   out <- nest_legacy(df, y)
   expect_equal(out$x, 1)
   expect_equal(length(out$data), 1L)
-  expect_equal(out$data[[1L]], data.frame(y = 1:3))
+  expect_equal(out$data[[1L]], tibble(y = 1:3))
 })
 
 test_that("can control output column name", {
@@ -27,7 +27,7 @@ test_that("can control output column name", {
 test_that("nest doesn't include grouping vars in nested data", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
   out <- df %>% dplyr::group_by(x) %>% nest_legacy()
-  expect_equal(out$data[[1]], data.frame(y = 1:3))
+  expect_equal(out$data[[1]], tibble(y = 1:3))
 })
 
 test_that("can restrict variables in grouped nest", {
@@ -136,10 +136,7 @@ test_that("can unnest mixture of name and unnamed lists of same length", {
 
 test_that("elements must all be of same type", {
   df <- tibble(x = list(1, "a"))
-  expect_error(
-    unnest_legacy(df),
-    "(incompatible type)|(numeric to character)|(character to numeric)"
-  )
+  expect_error(unnest_legacy(df), class = "vctrs_error_incompatible_type")
 })
 
 test_that("can't combine vectors and data frames", {
@@ -267,12 +264,12 @@ test_that("grouping is preserved", {
 
   expect_equal(rs$x, 1:3)
   expect_equal(class(df), class(rs))
-  expect_equal(dplyr::groups(df), dplyr::groups(rs))
+  expect_equal(dplyr::group_vars(df), dplyr::group_vars(rs))
 })
 
 test_that("unnesting zero row column preserves names", {
   df <- tibble(a = character(), b = character())
-  expect_equal(df %>% unnest_legacy(b), tibble(b = character(), a = character()))
+  expect_equal(df %>% unnest_legacy(b), tibble(a = character(), b = character()))
 })
 
 test_that("unnest_legacy() recognize ptype", {

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -7,14 +7,14 @@ test_that("nest turns grouped values into one list-df", {
   out <- nest(df, data = y)
   expect_equal(out$x, 1)
   expect_equal(length(out$data), 1L)
-  expect_equal(out$data[[1L]], data.frame(y = 1:3))
+  expect_equal(out$data[[1L]], tibble(y = 1:3))
 })
 
 test_that("nest uses grouping vars if present", {
   df <- tibble(x = c(1, 1, 1), y = 1:3)
   out <- df %>% dplyr::group_by(x) %>% nest()
   expect_s3_class(out, "grouped_df")
-  expect_equal(out$data[[1]], data.frame(y = 1:3))
+  expect_equal(out$data[[1]], tibble(y = 1:3))
 })
 
 test_that("provided grouping vars override grouped defaults", {
@@ -301,5 +301,5 @@ test_that("grouping is preserved", {
 
   expect_equal(rs$x, 1:3)
   expect_equal(class(df), class(rs))
-  expect_equal(dplyr::groups(df), dplyr::groups(rs))
+  expect_equal(dplyr::group_vars(df), dplyr::group_vars(rs))
 })

--- a/tests/testthat/test-separate-rows.R
+++ b/tests/testthat/test-separate-rows.R
@@ -21,7 +21,7 @@ test_that("preserves grouping", {
   rs <- df %>% separate_rows(x)
 
   expect_equal(class(df), class(rs))
-  expect_equal(dplyr::groups(df), dplyr::groups(rs))
+  expect_equal(dplyr::group_vars(df), dplyr::group_vars(rs))
 })
 
 test_that("drops grouping when needed", {
@@ -29,10 +29,10 @@ test_that("drops grouping when needed", {
 
   out <- df %>% separate_rows(y)
   expect_equal(out$y, c("a", "b"))
-  expect_equal(dplyr::groups(out), list(as.name("x")))
+  expect_equal(dplyr::group_vars(out), "x")
 
   out <- df %>% dplyr::group_by(y) %>% separate_rows(y)
-  expect_equal(dplyr::groups(out), NULL)
+  expect_equal(dplyr::group_vars(out), character())
 })
 
 test_that("convert produces integers etc", {

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -82,14 +82,14 @@ test_that("preserves grouping", {
   df <- tibble(g = 1, x = "a:b") %>% dplyr::group_by(g)
   rs <- df %>% separate(x, c("a", "b"))
   expect_equal(class(df), class(rs))
-  expect_equal(dplyr::groups(df), dplyr::groups(rs))
+  expect_equal(dplyr::group_vars(df), dplyr::group_vars(rs))
 })
 
 test_that("drops grouping when needed", {
   df <- tibble(x = "a:b") %>% dplyr::group_by(x)
   rs <- df %>% separate(x, c("a", "b"))
   expect_equal(rs$a, "a")
-  expect_equal(dplyr::groups(rs), NULL)
+  expect_equal(dplyr::group_vars(rs), character())
 })
 
 test_that("overwrites existing columns", {

--- a/tests/testthat/test-unite.R
+++ b/tests/testthat/test-unite.R
@@ -19,14 +19,14 @@ test_that("unite preserves grouping", {
   rs <- df %>% unite(x, x)
   expect_equal(df, rs)
   expect_equal(class(df), class(rs))
-  expect_equal(dplyr::groups(df), dplyr::groups(rs))
+  expect_equal(dplyr::group_vars(df), dplyr::group_vars(rs))
 })
 
 test_that("drops grouping when needed", {
   df <- tibble(g = 1, x = "a") %>% dplyr::group_by(g)
   rs <- df %>% unite(gx, g, x)
   expect_equal(rs$gx, "1_a")
-  expect_equal(dplyr::groups(rs), NULL)
+  expect_equal(dplyr::group_vars(rs), character())
 })
 
 test_that("empty var spec uses all vars", {


### PR DESCRIPTION
* Swap expected column order

* `complete()` moves selected columns to the front

* Removal of `all.equal()` from dplyr requires testing tibbles against tibbles

* Rework `enframe()` to avoid `dplyr::combine()`

* Update expected error to vctrs incompatible type

* Explicit grouping before calling `group_indices()` is now required

* Refactor `str_extract()` to avoid setting `NA` names on a tibble

* Preserve drop default of the `input`

* Consistently use `group_vars()` in tests to avoid `groups()` changes